### PR TITLE
Fixed broken resources link

### DIFF
--- a/index.html
+++ b/index.html
@@ -382,7 +382,7 @@
 	
     <h3 class="noprint">Resources</h3>
 	<ul class="noprint">
-		<li><a href="https://www.scmagazine.com/home/security-news/vulnerabilities/new-manifesto-offers-cisos-an-agile-guide-to-threat-modeling/" target="_blank">New manifesto offers CISOs an agile guide to threat modeling</a> article by Derek B. Johnson, SC Magazine</li>
+		<li><a href="https://www.scmagazine.com/news/threat-hunting/new-manifesto-offers-cisos-an-agile-guide-to-threat-modeling" target="_blank">New manifesto offers CISOs an agile guide to threat modeling</a> article by Derek B. Johnson, SC Magazine</li>
 		<li><a href="https://podcast.securityjourney.com/the-threat-modeling-manifesto-part-1/" target="_blank">The Threat Modeling Manifesto – Part 1</a> on the Application Security Podcast</li>
 		<li><a href="https://podcast.securityjourney.com/the-threat-modeling-manifesto-part-2/" target="_blank">The Threat Modeling Manifesto – Part 2</a> on the Application Security Podcast</li>
 		<li><a href="https://www.linddun.org/post/threat-modeling-manifesto-defines-the-foundation-of-threat-modeling" target="_blank">Threat Modeling Manifesto defines the foundation of threat modeling</a> article by Kim Wuyts, LINDDUN privacy</li>


### PR DESCRIPTION
Great work on this summary of really good threat modelling advice!

The first link under "Resources" gave me a 404 while checking out https://www.threatmodelingmanifesto.org/. I found the article on the site and added in a working link in this PR. Hopefully this is a good way to fix it.

