### PR TITLE
Fixed URL to PDF on main page.

### DIFF
--- a/index.html
+++ b/index.html
@@ -359,7 +359,7 @@
 	<p>Our intention for the Threat Modeling Manifesto is to share a distilled version of our collective threat modeling knowledge in a way that should inform, educate, and inspire other practitioners to adopt threat modeling as well as improve security and privacy during development.</p>
 	<p>We developed this Manifesto after years of experience thinking about, performing, teaching, and developing the practice of, Threat Modeling. We have diverse backgrounds as industry professionals, academics, authors, hands-on experts, and presenters. We bring together varied perspectives on threat modeling. Our ongoing conversations, which focus on the conditions and approaches that lead to the best results in threat modeling, as well as how to correct when we fail, continue to shape our ideas.</p>
 	
-	<p class="noprint">We provide a <a href="https://github.com/Threat-Modeling-Manifesto/threat-modeling-manifesto/releases/latest/download/threat-modeling-manifesto.pdf">PDF version</a> of the manifesto and this website is also <a href="javascript:window.print();">print friendly</a>.</a></p>
+	<p class="noprint">We provide a <a href="https://github.com/Threat-Modeling-Manifesto/threat-modeling-manifesto/releases/download/capabilities/threat-modeling-capabilities.pdf">PDF version</a> of the manifesto and this website is also <a href="javascript:window.print();">print friendly</a>.</a></p>
 
 	<p class="printonly">You can always find the current version of this manifesto at <a href="https://www.threatmodelingmanifesto.org/">https://www.threatmodelingmanifesto.org/</a>.</p>
 	


### PR DESCRIPTION
Looks like the PDF link on https://www.threatmodelingmanifesto.org/#about is broken. The one on the Capabilities subsite is fine.